### PR TITLE
enable SCF for MCH

### DIFF
--- a/Modules/input_parameters.f90
+++ b/Modules/input_parameters.f90
@@ -32,6 +32,7 @@ MODULE input_parameters
   USE parameters, ONLY : nsx, natx, sc_size
   USE wannier_new,ONLY : wannier_data
   USE upf_params, ONLY : lqmax
+  USE constants,  ONLY : BOHR_RADIUS_ANGS
   !
   IMPLICIT NONE
   !
@@ -634,7 +635,7 @@ MODULE input_parameters
         !! Use 2D moire potential
         !
         ! the following are the needed parameters for 2D moire potential
-        REAL(DP) :: amoire_in_ang = 1.d0
+        REAL(DP) :: amoire_in_ang = BOHR_RADIUS_ANGS
         !! moire lattice constant in Angstrom
         !
         REAL(DP) :: vmoire_in_mev = 0.d0

--- a/Modules/input_parameters.f90
+++ b/Modules/input_parameters.f90
@@ -644,6 +644,9 @@ MODULE input_parameters
         REAL(DP) :: pmoire_in_deg = 60.d0
         !! moire potential "shape" in degrees
         !
+        REAL(DP) :: epsmoire = 1.d0
+        !! moire in-plane dielectric constant
+        !
         REAL(DP) :: mstar = 1.d0
         !! effective mass of electrons in lowest band
         !
@@ -682,7 +685,8 @@ MODULE input_parameters
              gcscf_gk, gcscf_gh, gcscf_beta,                                  &
              space_group, uniqueb, origin_choice, rhombohedral,               &
              zgate, relaxz, block, block_1, block_2, block_height,            &
-             lmoire, amoire_in_ang, vmoire_in_mev, pmoire_in_deg, mstar
+             lmoire, amoire_in_ang, vmoire_in_mev, pmoire_in_deg, mstar,      &
+             epsmoire
 
 !=----------------------------------------------------------------------------=!
 !  ELECTRONS Namelist Input Parameters

--- a/Modules/input_parameters.f90
+++ b/Modules/input_parameters.f90
@@ -634,8 +634,8 @@ MODULE input_parameters
         !! Use 2D moire potential
         !
         ! the following are the needed parameters for 2D moire potential
-        REAL(DP) :: amoire_in_nm = 1.d0
-        !! moire lattice constant in nm
+        REAL(DP) :: amoire_in_ang = 1.d0
+        !! moire lattice constant in Angstrom
         !
         REAL(DP) :: vmoire_in_mev = 0.d0
         !! moire potential depth in meV
@@ -681,7 +681,7 @@ MODULE input_parameters
              gcscf_gk, gcscf_gh, gcscf_beta,                                  &
              space_group, uniqueb, origin_choice, rhombohedral,               &
              zgate, relaxz, block, block_1, block_2, block_height,            &
-             lmoire, amoire_in_nm, vmoire_in_mev, pmoire_in_deg, mstar
+             lmoire, amoire_in_ang, vmoire_in_mev, pmoire_in_deg, mstar
 
 !=----------------------------------------------------------------------------=!
 !  ELECTRONS Namelist Input Parameters

--- a/Modules/input_parameters.f90
+++ b/Modules/input_parameters.f90
@@ -630,7 +630,22 @@ MODULE input_parameters
         !! in rhombohedral axes. If FALSE in hexagonal axes, that are
         !! converted internally in rhombohedral axes.  
         !
-
+        LOGICAL :: lmoire = .false.
+        !! Use 2D moire potential
+        !
+        ! the following are the needed parameters for 2D moire potential
+        REAL(DP) :: amoire_in_nm = 1.d0
+        !! moire lattice constant in nm
+        !
+        REAL(DP) :: vmoire_in_mev = 0.d0
+        !! moire potential depth in meV
+        !
+        REAL(DP) :: pmoire_in_deg = 60.d0
+        !! moire potential "shape" in degrees
+        !
+        REAL(DP) :: mstar = 1.d0
+        !! effective mass of electrons in lowest band
+        !
 
 
         NAMELIST / system / ibrav, celldm, a, b, c, cosab, cosac, cosbc, nat, &
@@ -665,7 +680,8 @@ MODULE input_parameters
              lgcscf, gcscf_ignore_mun, gcscf_mu, gcscf_conv_thr,              &
              gcscf_gk, gcscf_gh, gcscf_beta,                                  &
              space_group, uniqueb, origin_choice, rhombohedral,               &
-             zgate, relaxz, block, block_1, block_2, block_height
+             zgate, relaxz, block, block_1, block_2, block_height,            &
+             lmoire, amoire_in_nm, vmoire_in_mev, pmoire_in_deg, mstar
 
 !=----------------------------------------------------------------------------=!
 !  ELECTRONS Namelist Input Parameters

--- a/Modules/input_parameters.f90
+++ b/Modules/input_parameters.f90
@@ -1024,6 +1024,10 @@ MODULE input_parameters
         !! Time step for CP-BO electron minimization dynamics, in atomic units.
         !! CP: \(1 \text{a.u. of time} = 2.4189\cdot 10^{-17} s\), PW: twice that much.
 
+        LOGICAL :: extra_cycle = .false.
+        !! one more electrons_scf after exx convergence for energy components
+        !
+
         NAMELIST / electrons / emass, emass_cutoff, orthogonalization, &
           electron_maxstep, scf_must_converge, ortho_eps, ortho_max, electron_dynamics,   &
           electron_damping, electron_velocities, electron_temperature, &
@@ -1044,7 +1048,7 @@ MODULE input_parameters
           occupation_constraints, niter_cg_restart,                    &
           niter_cold_restart, lambda_cold, efield_cart, real_space,    &
           tcpbo,emass_emin, emass_cutoff_emin, electron_damping_emin,  &
-          dt_emin, efield_phase
+          dt_emin, efield_phase, extra_cycle
 
 !
 !=----------------------------------------------------------------------------=!

--- a/Modules/read_namelists.f90
+++ b/Modules/read_namelists.f90
@@ -848,6 +848,7 @@ MODULE read_namelists_module
        CALL mp_bcast( vmoire_in_mev,     ionode_id, intra_image_comm )
        CALL mp_bcast( pmoire_in_deg,     ionode_id, intra_image_comm )
        CALL mp_bcast( mstar,             ionode_id, intra_image_comm )
+       CALL mp_bcast( epsmoire,          ionode_id, intra_image_comm )
 
        ! ... EXX
 

--- a/Modules/read_namelists.f90
+++ b/Modules/read_namelists.f90
@@ -843,6 +843,11 @@ MODULE read_namelists_module
        CALL mp_bcast( qcutz,             ionode_id, intra_image_comm )
        CALL mp_bcast( q2sigma,           ionode_id, intra_image_comm )
        CALL mp_bcast( input_dft,         ionode_id, intra_image_comm )
+       CALL mp_bcast( lmoire,            ionode_id, intra_image_comm )
+       CALL mp_bcast( amoire_in_ang,     ionode_id, intra_image_comm )
+       CALL mp_bcast( vmoire_in_mev,     ionode_id, intra_image_comm )
+       CALL mp_bcast( pmoire_in_deg,     ionode_id, intra_image_comm )
+       CALL mp_bcast( mstar,             ionode_id, intra_image_comm )
 
        ! ... EXX
 

--- a/Modules/read_namelists.f90
+++ b/Modules/read_namelists.f90
@@ -991,6 +991,7 @@ MODULE read_namelists_module
        !
        IMPLICIT NONE
        !
+       CALL mp_bcast( extra_cycle,          ionode_id, intra_image_comm )
        CALL mp_bcast( emass,                ionode_id, intra_image_comm )
        CALL mp_bcast( emass_cutoff,         ionode_id, intra_image_comm )
        CALL mp_bcast( orthogonalization,    ionode_id, intra_image_comm )

--- a/PW/src/electrons.f90
+++ b/PW/src/electrons.f90
@@ -491,7 +491,9 @@ SUBROUTINE electrons_scf ( printout, exxen )
   !! auxiliary variables for grimme-d3
   LOGICAL :: lhb
   !! if .TRUE. then background states are present (DFT+U)
+  LOGICAL :: lmoire
   !
+  lmoire = .true.
   lhb = .FALSE.
   IF ( lda_plus_u )  THEN
      DO nt = 1, ntyp
@@ -515,12 +517,16 @@ SUBROUTINE electrons_scf ( printout, exxen )
   !
   ! ... calculates the ewald contribution to total energy
   !
+  if (lmoire) then
+   ewld = 0.d0
+  else
   IF ( do_comp_esm ) THEN
      ewld = esm_ewald()
   ELSE
      ewld = ewald( alat, nat, nsp, ityp, zv, at, bg, tau, &
                 omega, g, gg, ngm, gcutm, gstart, gamma_only, strf )
   ENDIF
+  endif ! lmoire
   !
   IF ( llondon ) THEN
      elondon = energy_london( alat , nat , ityp , at ,bg , tau )

--- a/PW/src/electrons.f90
+++ b/PW/src/electrons.f90
@@ -436,6 +436,7 @@ SUBROUTINE electrons_scf ( printout, exxen )
   USE wvfct_gpum,           ONLY : using_et
   USE scf_gpum,             ONLY : using_vrs
   USE device_fbuff_m,             ONLY : dev_buf, pin_buf
+  USE input_parameters,     ONLY : lmoire
   !
   IMPLICIT NONE
   !
@@ -491,9 +492,7 @@ SUBROUTINE electrons_scf ( printout, exxen )
   !! auxiliary variables for grimme-d3
   LOGICAL :: lhb
   !! if .TRUE. then background states are present (DFT+U)
-  LOGICAL :: lmoire
   !
-  lmoire = .true.
   lhb = .FALSE.
   IF ( lda_plus_u )  THEN
      DO nt = 1, ntyp

--- a/PW/src/electrons.f90
+++ b/PW/src/electrons.f90
@@ -51,7 +51,7 @@ SUBROUTINE electrons()
   !
   USE wvfct_gpum,           ONLY : using_et, using_wg, using_wg_d
   USE scf_gpum,             ONLY : using_vrs
-
+  USE input_parameters,     ONLY : extra_cycle
   !
   IMPLICIT NONE
   !
@@ -283,6 +283,13 @@ SUBROUTINE electrons()
         !
         IF ( dexx < tr2_final ) THEN
            WRITE( stdout, 9066 ) '!!', etot, hwf_energy
+           if (extra_cycle) then
+             printout = 2
+             call electrons_scf(printout, exxen)
+             write( stdout, 9069 ) eband+deband-2*exxen
+             write( stdout, 9070 ) ehart
+             write( stdout, 9071 ) exxen
+           endif
         ELSE
            WRITE( stdout, 9066 ) '  ', etot, hwf_energy
         ENDIF
@@ -344,6 +351,9 @@ SUBROUTINE electrons()
             /'     Harris-Foulkes estimate   =',0PF17.8,' Ry' )
 9067 FORMAT('     est. exchange err (dexx)  =',0PF17.8,' Ry' )
 9068 FORMAT('     est. exchange err (dexx)  =',1PE17.1,' Ry' )
+9069 FORMAT( '    E1 (T+V)                   =',0PF17.8,' Ry' )
+9070 FORMAT( '    EJ (ehart)                 =',0PF17.8,' Ry' )
+9071 FORMAT( '    EX (exxen)                 =',0PF17.8,' Ry' )
 9101 FORMAT(/'     EXX self-consistency reached' )
 9120 FORMAT(/'     EXX convergence NOT achieved after ',i3,' iterations: stopping' )
 9121 FORMAT(/'     scf convergence threshold =',1PE17.1,' Ry' )

--- a/PW/src/electrons.f90
+++ b/PW/src/electrons.f90
@@ -286,9 +286,9 @@ SUBROUTINE electrons()
            if (extra_cycle) then
              printout = 2
              call electrons_scf(printout, exxen)
-             write( stdout, 9069 ) eband+deband-2*exxen
-             write( stdout, 9070 ) ehart
-             write( stdout, 9071 ) exxen
+             write( stdout, 9069 ) (eband+deband-2*exxen)/2.d0
+             write( stdout, 9070 ) ehart/2.d0
+             write( stdout, 9071 ) exxen/2.d0
            endif
         ELSE
            WRITE( stdout, 9066 ) '  ', etot, hwf_energy
@@ -351,9 +351,9 @@ SUBROUTINE electrons()
             /'     Harris-Foulkes estimate   =',0PF17.8,' Ry' )
 9067 FORMAT('     est. exchange err (dexx)  =',0PF17.8,' Ry' )
 9068 FORMAT('     est. exchange err (dexx)  =',1PE17.1,' Ry' )
-9069 FORMAT( '    E1 (T+V)                   =',0PF17.8,' Ry' )
-9070 FORMAT( '    EJ (ehart)                 =',0PF17.8,' Ry' )
-9071 FORMAT( '    EX (exxen)                 =',0PF17.8,' Ry' )
+9069 FORMAT( '    E1 (T+V)                   =',0PF17.8,' Ha/kpt' )
+9070 FORMAT( '    EJ (ehart)                 =',0PF17.8,' Ha/kpt' )
+9071 FORMAT( '    EX (exxen)                 =',0PF17.8,' Ha/kpt' )
 9101 FORMAT(/'     EXX self-consistency reached' )
 9120 FORMAT(/'     EXX convergence NOT achieved after ',i3,' iterations: stopping' )
 9121 FORMAT(/'     scf convergence threshold =',1PE17.1,' Ry' )

--- a/PW/src/exx.f90
+++ b/PW/src/exx.f90
@@ -4398,6 +4398,7 @@ end associate
     USE mp_bands,          ONLY : intra_bgrp_comm, me_bgrp, nproc_bgrp
     USE exx_base,          ONLY : nqs, xkq_collect, index_xkq, index_xk, &
                                   g2_convolution
+    USE input_parameters,  ONLY : lmoire
     !
     IMPLICIT NONE
     !
@@ -4469,6 +4470,7 @@ end associate
            ENDDO  
            !
            CALL invfft( 'Rho', vc, dfftt )
+           if (lmoire) vc(:) = vc(:) * dfftt%nr3x
            !
            DO ir = 1, NQR   
              RESULT(ir,ibnd) = RESULT(ir,ibnd) + locbuff(ir,ibnd,ikq) * vc(ir)   
@@ -4500,6 +4502,7 @@ end associate
              ENDDO
              !
              CALL invfft( 'Rho', vc, dfftt )
+             if (lmoire) vc(:) = vc(:) * dfftt%nr3x
              !
              DO ir = 1, NQR   
                RESULT(ir,kbnd) = RESULT(ir,kbnd) + x_occupation(ibnd,ikq) * locbuff(ir,ibnd,ikq) * vc(ir)   

--- a/PW/src/exx_base.f90
+++ b/PW/src/exx_base.f90
@@ -720,7 +720,9 @@ MODULE exx_base
     !
     USE kinds,      ONLY : DP
     USE cell_base,  ONLY : tpiba, at, tpiba2
-    USE constants,  ONLY : fpi, e2, pi
+    USE constants,  ONLY : fpi, e2, pi, tpi, eps8
+    USE constants,  ONLY : BOHR_RADIUS_ANGS
+    USE input_parameters, ONLY : lmoire, epsmoire, amoire_in_ang
     !
     IMPLICIT NONE
     !
@@ -742,6 +744,8 @@ MODULE exx_base
     REAL(DP) :: grid_factor_track(ngm), qq_track(ngm)
     REAL(DP) :: nqhalf_dble(3)
     LOGICAL :: odg(3)
+    double precision :: amoire
+    amoire = amoire_in_ang/BOHR_RADIUS_ANGS
     !
     ! ... First the types of Coulomb potential that need q(3) and an external call
     IF( use_coulomb_vcut_ws ) THEN
@@ -811,7 +815,12 @@ MODULE exx_base
          ELSEIF( erf_scrlen > 0 ) THEN
             fac(ig) = e2*fpi/qq*(EXP(-qq/4._DP/erf_scrlen**2)) * grid_factor_track(ig)
          ELSE
+            if (lmoire) then
+            if (abs(g(3,ig)) > eps8) cycle
+            fac(ig) = e2*tpi/( sqrt(qq) + yukawa )/(epsmoire*amoire) * grid_factor_track(ig)
+            else
             fac(ig) = e2*fpi/( qq + yukawa ) * grid_factor_track(ig) ! as HARTREE
+            endif ! lmoire
          ENDIF
          !
       ELSE

--- a/PW/src/exx_base.f90
+++ b/PW/src/exx_base.f90
@@ -719,7 +719,7 @@ MODULE exx_base
     !! It then regularizes it according to the specified recipe.
     !
     USE kinds,      ONLY : DP
-    USE cell_base,  ONLY : tpiba, at, tpiba2
+    USE cell_base,  ONLY : tpiba, at, tpiba2, alat
     USE constants,  ONLY : fpi, e2, pi, tpi, eps8
     USE constants,  ONLY : BOHR_RADIUS_ANGS
     USE input_parameters, ONLY : lmoire, epsmoire, amoire_in_ang
@@ -817,7 +817,7 @@ MODULE exx_base
          ELSE
             if (lmoire) then
             if (abs(g(3,ig)) > eps8) cycle
-            fac(ig) = e2*tpi/( sqrt(qq) + yukawa )/(epsmoire*amoire)*at(3,3) * grid_factor_track(ig)
+            fac(ig) = e2*tpi/( sqrt(qq) + yukawa )/(epsmoire*amoire)*at(3,3)*alat * grid_factor_track(ig)
             else
             fac(ig) = e2*fpi/( qq + yukawa ) * grid_factor_track(ig) ! as HARTREE
             endif ! lmoire

--- a/PW/src/exx_base.f90
+++ b/PW/src/exx_base.f90
@@ -817,7 +817,7 @@ MODULE exx_base
          ELSE
             if (lmoire) then
             if (abs(g(3,ig)) > eps8) cycle
-            fac(ig) = e2*tpi/( sqrt(qq) + yukawa )/(epsmoire*amoire) * grid_factor_track(ig)
+            fac(ig) = e2*tpi/( sqrt(qq) + yukawa )/(epsmoire*amoire)*at(3,3) * grid_factor_track(ig)
             else
             fac(ig) = e2*fpi/( qq + yukawa ) * grid_factor_track(ig) ! as HARTREE
             endif ! lmoire

--- a/PW/src/g2_kin.f90
+++ b/PW/src/g2_kin.f90
@@ -23,17 +23,19 @@ SUBROUTINE g2_kin( ik )
   IMPLICIT NONE
   !
   INTEGER, INTENT(IN) :: ik
+  DOUBLE PRECISION :: wm
   !
   ! ... local variables
   !
   INTEGER :: ig, npw
   !
   !
+  wm = 2*7.111835442262301e-05  ! am = 75 nm, mstar = 0.35
   CALL using_g2kin(1)
   npw = ngk(ik)
   g2kin(1:npw) = ( ( xk(1,ik) + g(1,igk_k(1:npw,ik)) )**2 + &
                    ( xk(2,ik) + g(2,igk_k(1:npw,ik)) )**2 + &
-                   ( xk(3,ik) + g(3,igk_k(1:npw,ik)) )**2 ) * tpiba2
+                   ( xk(3,ik) + g(3,igk_k(1:npw,ik)) )**2 ) * tpiba2 * wm
   !
   IF ( qcutz > 0.D0 ) THEN
      !

--- a/PW/src/g2_kin.f90
+++ b/PW/src/g2_kin.f90
@@ -19,23 +19,30 @@ SUBROUTINE g2_kin( ik )
   USE gvecw,                ONLY : ecfixed, qcutz, q2sigma
   USE wvfct,                ONLY : g2kin
   USE wvfct_gpum,           ONLY : using_g2kin
+  USE constants,            ONLY : BOHR_RADIUS_ANGS
+  USE input_parameters,     ONLY : lmoire, amoire_in_ang, mstar
   !
   IMPLICIT NONE
   !
   INTEGER, INTENT(IN) :: ik
-  DOUBLE PRECISION :: wm
   !
   ! ... local variables
   !
   INTEGER :: ig, npw
+  DOUBLE PRECISION :: wm, amoire, k2pre
   !
-  !
-  wm = 2*7.111835442262301e-05  ! am = 75 nm, mstar = 0.35
+  if (lmoire) then
+    amoire = amoire_in_ang/BOHR_RADIUS_ANGS
+    wm = 1.d0/(mstar*amoire**2)
+    k2pre = tpiba2*wm
+  else
+    k2pre = tpiba2
+  endif
   CALL using_g2kin(1)
   npw = ngk(ik)
   g2kin(1:npw) = ( ( xk(1,ik) + g(1,igk_k(1:npw,ik)) )**2 + &
                    ( xk(2,ik) + g(2,igk_k(1:npw,ik)) )**2 + &
-                   ( xk(3,ik) + g(3,igk_k(1:npw,ik)) )**2 ) * tpiba2 * wm
+                   ( xk(3,ik) + g(3,igk_k(1:npw,ik)) )**2 ) * k2pre
   !
   IF ( qcutz > 0.D0 ) THEN
      !

--- a/PW/src/g2_kin_gpu.f90
+++ b/PW/src/g2_kin_gpu.f90
@@ -18,6 +18,8 @@ SUBROUTINE g2_kin_gpu ( ik )
   USE klist,                ONLY : xk, ngk, igk_k_d
   USE gvect,                ONLY : g_d
   USE wvfct_gpum,           ONLY : g2kin_d, using_g2kin_d
+  USE constants,            ONLY : BOHR_RADIUS_ANGS
+  USE input_parameters,     ONLY : lmoire, amoire_in_ang, mstar
   !
   IMPLICIT NONE
   !
@@ -27,7 +29,15 @@ SUBROUTINE g2_kin_gpu ( ik )
   !
   INTEGER :: ig, npw,i
   REAL(DP):: xk1,xk2,xk3
+  DOUBLE PRECISION :: wm, amoire, k2pre
   !
+  if (lmoire) then
+    amoire = amoire_in_ang/BOHR_RADIUS_ANGS
+    wm = 1.d0/(mstar*amoire**2)
+    k2pre = tpiba2*wm
+  else
+    k2pre = tpiba2
+  endif
   CALL using_g2kin_d(2)
   !
   npw = ngk(ik)
@@ -40,7 +50,7 @@ SUBROUTINE g2_kin_gpu ( ik )
   DO i=1,npw
      g2kin_d(i) = ( ( xk1 + g_d(1,igk_k_d(i,ik)) )*( xk1 + g_d(1,igk_k_d(i,ik)) ) + &
                   ( xk2 + g_d(2,igk_k_d(i,ik)) )*( xk2 + g_d(2,igk_k_d(i,ik)) ) + &
-                  ( xk3 + g_d(3,igk_k_d(i,ik)) )*( xk3 + g_d(3,igk_k_d(i,ik)) ) ) * tpiba2
+                  ( xk3 + g_d(3,igk_k_d(i,ik)) )*( xk3 + g_d(3,igk_k_d(i,ik)) ) ) * k2pre
   !
   END DO
   !

--- a/PW/src/set_vrs.f90
+++ b/PW/src/set_vrs.f90
@@ -79,7 +79,7 @@ SUBROUTINE sum_vrs( nrxx, nspin, vltot, vr, vrs )
         !
         vrs(:,is) = vr(:,is)
      ELSE
-        vrs(:,is) = vltot(:) + vr(:,is)
+        vrs(:,is) = vltot(:) !+ vr(:,is)
      ENDIF
      !
   ENDDO

--- a/PW/src/set_vrs.f90
+++ b/PW/src/set_vrs.f90
@@ -79,7 +79,7 @@ SUBROUTINE sum_vrs( nrxx, nspin, vltot, vr, vrs )
         !
         vrs(:,is) = vr(:,is)
      ELSE
-        vrs(:,is) = vltot(:) !+ vr(:,is)
+        vrs(:,is) = vltot(:) + vr(:,is)
      ENDIF
      !
   ENDDO

--- a/PW/src/setlocal.f90
+++ b/PW/src/setlocal.f90
@@ -17,7 +17,7 @@ SUBROUTINE setlocal
   !
   USE io_global,         ONLY : stdout
   USE kinds,             ONLY : DP
-  USE constants,         ONLY : eps8, pi, AUTOEV
+  USE constants,         ONLY : eps8, pi, AUTOEV, e2
   USE ions_base,         ONLY : zv, ntyp => nsp, nat, tau
   USE cell_base,         ONLY : omega, at, bg
   USE extfield,          ONLY : tefield, dipfield, etotefield, gate, &
@@ -52,7 +52,7 @@ SUBROUTINE setlocal
   !
   if (lmoire) then
   vltot(:) = 0.d0
-  vm = vmoire_in_mev*1e-3/AUTOEV
+  vm = vmoire_in_mev*1e-3/AUTOEV*e2  ! e2 converts Ha to Ry
   phi = pmoire_in_deg/180.d0*pi
   call hex_shell(g6)
   write(stdout, '("     Moire potential Vm = ",f12.2," meV on G shell:")') vmoire_in_mev
@@ -75,7 +75,7 @@ SUBROUTINE setlocal
       gj = g6(:,2*jg)
       vj = vj+2*cos(phi+dot_product(gj,rvec))
     enddo gj_loop
-    vltot(ir) = vm*vj/omega
+    vltot(ir) = vm*vj
     !write(42, '(3f16.8,f16.8)') rvec, vltot(ir)
   enddo r_loop
   v_of_0 = sum(vltot)/dfftp%nnr

--- a/PW/src/setlocal.f90
+++ b/PW/src/setlocal.f90
@@ -171,7 +171,7 @@ subroutine hex_shell(g6_out)
     if (abs(norm2(g1)-4.d0*pi/sqrt(3.d0)) < eps8) then
       if (ih > 6) call errore('setlocal', 'more than 6 k points in first shell', 1)
       g6(1:3,ih) = g1(1:3)
-      angles(ih) = atan(g1(2), g1(1))
+      angles(ih) = atan2(g1(2), g1(1))
       ih = ih+1
     endif
   enddo

--- a/PW/src/setlocal.f90
+++ b/PW/src/setlocal.f90
@@ -71,7 +71,7 @@ SUBROUTINE setlocal
       gj = g6(:,2*jg)
       vj = vj+2*cos(phi+dot_product(gj,rvec))
     enddo gj_loop
-    vltot(ir) = vm*vj
+    vltot(ir) = vm*vj/omega
     !write(42, '(3f16.8,f16.8)') rvec, vltot(ir)
   enddo
   enddo r_loop

--- a/PW/src/setlocal.f90
+++ b/PW/src/setlocal.f90
@@ -41,9 +41,8 @@ SUBROUTINE setlocal
   !
   COMPLEX(DP), ALLOCATABLE :: aux(:), v_corr(:)
   ! auxiliary variable
-  INTEGER :: nt, ng, ir, ni, nj, nk, jg, m1j, iat
-  DOUBLE PRECISION :: rvec(3), gj(3), vm, phi, g6(3,6)
-  COMPLEX(DP) :: atm_phase, vj
+  INTEGER :: nt, ng, ir, ni, nj, nk, jg, iat
+  DOUBLE PRECISION :: rvec(3), gj(3), vm, phi, g6(3,6), vj
   ! counter on atom types
   ! counter on g vectors
   !
@@ -67,18 +66,13 @@ SUBROUTINE setlocal
                 nj*at(1:3,2)/REAL(dfftp%nr2, DP) + &
                 nk*at(1:3,3)/REAL(dfftp%nr3, DP)
     ! loop over hex_shell
-    m1j = -1
-    vj = (0.d0, 0.d0)
-    gj_loop: do jg=1,6
-      gj = g6(:,jg)
-      atm_phase = (0.d0, 0.d0)
-      atm_loop: do iat=1,nat
-        atm_phase = atm_phase + exp(-1.d0*m1j*(0.d0, 1.d0)*phi*dot_product(gj,tau(:,iat)))
-      enddo atm_loop
-      vj = vj + atm_phase*exp(m1j*(0.d0, 1.d0)*phi*dot_product(gj,rvec))
-      m1j = -1*m1j
+    vj = 0.d0
+    gj_loop: do jg=1,3
+      gj = g6(:,2*jg)
+      vj = vj+2*cos(phi+dot_product(gj,rvec))
     enddo gj_loop
     vltot(ir) = vm*vj
+    !write(42, '(3f16.8,f16.8)') rvec, vltot(ir)
   enddo
   enddo r_loop
   v_of_0 = sum(vltot)/dfftp%nnr

--- a/PW/src/setlocal.f90
+++ b/PW/src/setlocal.f90
@@ -76,7 +76,7 @@ SUBROUTINE setlocal
       vj = vj+2*cos(phi+dot_product(gj,rvec))
     enddo gj_loop
     vltot(ir) = vm*vj
-    write(42, '(3f16.8,f16.8)') rvec, vltot(ir)
+    !write(42, '(3f16.8,f16.8)') rvec, vltot(ir)
   enddo r_loop
   v_of_0 = sum(vltot)/dfftp%nnr
   call mp_sum(v_of_0, intra_bgrp_comm)

--- a/PW/src/setlocal.f90
+++ b/PW/src/setlocal.f90
@@ -160,22 +160,23 @@ subroutine hex_shell(g6_out)
   USE cell_base,         ONLY : bg, tpiba
   implicit none
   double precision, intent(out) :: g6_out(3,6)
-  double precision :: g1(3), g6(3,6), angles(6)
+  double precision :: g1(3), g6(3,6), angles(6), bmag
   integer iangs(6), ih, ib1, ib2
+  g6_out(:,:) = 0.d0
+  bmag = tpiba * 2.d0/3.d0**0.5 ! first shell
   ! sort first shell of neighbors counter-clockwise from 9 o'clock (iangs)
   ih = 1
   do ib1 = -1,1
   do ib2 = -1,1
     g1 = ib1*bg(:, 1)*tpiba + ib2*bg(:, 2)*tpiba
-    if (abs(g1(3)) > eps8) continue
-    if (abs(norm2(g1)-4.d0*pi/sqrt(3.d0)) < eps8) then
-      if (ih > 6) call errore('setlocal', 'more than 6 k points in first shell', 1)
-      g6(1:3,ih) = g1(1:3)
+    if (abs(g1(3)) > eps8) call errore('hex_shell', 'z component', 1)
+    if (abs(norm2(g1)-bmag) < eps8) then
+      if (ih > 6) call errore('hex_shell', 'more than 6 k points in first shell', 1)
+      g6(:,ih) = g1
       angles(ih) = atan2(g1(2), g1(1))
       ih = ih+1
     endif
   enddo
-  if (abs(g1(3)) < eps8) continue
   enddo
   call hpsort(6, angles, iangs)
   do ih=1,6

--- a/PW/src/setlocal.f90
+++ b/PW/src/setlocal.f90
@@ -41,12 +41,17 @@ SUBROUTINE setlocal
   COMPLEX(DP), ALLOCATABLE :: aux(:), v_corr(:)
   ! auxiliary variable
   INTEGER :: nt, ng
+  LOGICAL :: lmoire
+  lmoire = .true.
   ! counter on atom types
   ! counter on g vectors
   !
   ALLOCATE( aux(dfftp%nnr) )
   aux(:) = (0.d0,0.d0)
   !
+  if (lmoire) then
+  vltot(:) = 0.d0
+  else
   IF (do_comp_mt) THEN
      ALLOCATE( v_corr(ngm) )
      CALL wg_corr_loc( omega, ntyp, ngm, zv, strf, v_corr )
@@ -96,6 +101,7 @@ SUBROUTINE setlocal
   CALL invfft( 'Rho', aux, dfftp )
   !
   vltot(:) =  DBLE( aux(:) )
+  endif ! lmoire
   !
   ! ... If required add an electric field to the local potential 
   !

--- a/PW/src/v_of_rho.f90
+++ b/PW/src/v_of_rho.f90
@@ -517,7 +517,7 @@ SUBROUTINE v_h( rhog, ehart, charge, v )
   USE fft_interfaces,    ONLY : invfft
   USE gvect,             ONLY : ngm, gg, gstart, g
   USE lsda_mod,          ONLY : nspin
-  USE cell_base,         ONLY : omega, tpiba2, tpiba, at
+  USE cell_base,         ONLY : omega, tpiba2, tpiba, at, alat
   USE control_flags,     ONLY : gamma_only
   USE mp_bands,          ONLY : intra_bgrp_comm
   USE mp,                ONLY : mp_sum
@@ -599,7 +599,7 @@ SUBROUTINE v_h( rhog, ehart, charge, v )
      ENDIF
      !
      if (lmoire) then
-     fac = e2 * tpi / tpiba / (epsmoire*amoire) * at(3, 3)
+     fac = e2 * tpi / tpiba / (epsmoire*amoire) * at(3, 3)*alat
      else
      fac = e2 * fpi / tpiba2
      endif ! lmoire

--- a/PW/src/v_of_rho.f90
+++ b/PW/src/v_of_rho.f90
@@ -517,7 +517,7 @@ SUBROUTINE v_h( rhog, ehart, charge, v )
   USE fft_interfaces,    ONLY : invfft
   USE gvect,             ONLY : ngm, gg, gstart, g
   USE lsda_mod,          ONLY : nspin
-  USE cell_base,         ONLY : omega, tpiba2, tpiba
+  USE cell_base,         ONLY : omega, tpiba2, tpiba, at
   USE control_flags,     ONLY : gamma_only
   USE mp_bands,          ONLY : intra_bgrp_comm
   USE mp,                ONLY : mp_sum
@@ -599,7 +599,7 @@ SUBROUTINE v_h( rhog, ehart, charge, v )
      ENDIF
      !
      if (lmoire) then
-     fac = e2 * tpi / tpiba / (epsmoire*amoire)
+     fac = e2 * tpi / tpiba / (epsmoire*amoire) * at(3, 3)
      else
      fac = e2 * fpi / tpiba2
      endif ! lmoire


### PR DESCRIPTION
setlocal.f90 is most heavily edited.
kinetic: g2_kin and g2_kin_gpu
ehart: v_of_rho::v_h coulomb `fac`
exx:  exx_base::g2_convolution

The nr3x hacks in exx.f90 and v_h.f90 have NOT been checked.