### PR TITLE
Use effetive Bohr and effective Rydberg

### DIFF
--- a/Modules/input_parameters.f90
+++ b/Modules/input_parameters.f90
@@ -263,6 +263,9 @@ MODULE input_parameters
         LOGICAL :: tqmmm = .FALSE.
         !! QM/MM coupling. enabled if TRUE
 
+        LOGICAL :: lob = .FALSE.
+        !! one-body calculation. enabled if TRUE
+
         CHARACTER(len=256) :: vdw_table_name = ' '
 
         CHARACTER(len=10) :: point_label_type='SC'
@@ -288,7 +291,7 @@ MODULE input_parameters
           gdir, nppstr, wf_collect, lelfield, nberrycyc, refg,            &
           tefield2, saverho, tabps, use_wannier, lecrpa,                  &
           lfcp, tqmmm, vdw_table_name, lorbm, memory, point_label_type,   &
-          input_xml_schema_file, gate
+          input_xml_schema_file, gate, lob
 !
 !=----------------------------------------------------------------------------=!
 !  SYSTEM Namelist Input Parameters

--- a/Modules/read_namelists.f90
+++ b/Modules/read_namelists.f90
@@ -789,6 +789,7 @@ MODULE read_namelists_module
        CALL mp_bcast( input_xml_schema_file, ionode_id, intra_image_comm )
        CALL mp_bcast( gate,          ionode_id, intra_image_comm ) !TB
        CALL mp_bcast( mbd_vdw,        ionode_id, intra_image_comm ) !GSz
+       CALL mp_bcast( lob,           ionode_id, intra_image_comm )
        !
        RETURN
        !

--- a/PW/src/exx_base.f90
+++ b/PW/src/exx_base.f90
@@ -723,6 +723,7 @@ MODULE exx_base
     USE constants,  ONLY : fpi, e2, pi, tpi, eps8
     USE constants,  ONLY : BOHR_RADIUS_ANGS
     USE moire,      ONLY : lmoire, amoire
+    USE input_parameters, ONLY: epsmoire
     !
     IMPLICIT NONE
     !
@@ -815,7 +816,7 @@ MODULE exx_base
          ELSE
             if (lmoire) then
             if (abs(g(3,ig)) > eps8) cycle
-            fac(ig) = e2*tpi/( sqrt(qq) + yukawa )/amoire*at(3,3)*alat * grid_factor_track(ig)
+            fac(ig) = e2*tpi/( sqrt(qq) + yukawa )/amoire/epsmoire*at(3,3)*alat * grid_factor_track(ig)
             else
             fac(ig) = e2*fpi/( qq + yukawa ) * grid_factor_track(ig) ! as HARTREE
             endif ! lmoire

--- a/PW/src/exx_base.f90
+++ b/PW/src/exx_base.f90
@@ -722,7 +722,7 @@ MODULE exx_base
     USE cell_base,  ONLY : tpiba, at, tpiba2, alat
     USE constants,  ONLY : fpi, e2, pi, tpi, eps8
     USE constants,  ONLY : BOHR_RADIUS_ANGS
-    USE moire,      ONLY : lmoire, amoire
+    USE moire,      ONLY : lmoire
     !
     IMPLICIT NONE
     !
@@ -815,7 +815,7 @@ MODULE exx_base
          ELSE
             if (lmoire) then
             if (abs(g(3,ig)) > eps8) cycle
-            fac(ig) = e2*tpi/( sqrt(qq) + yukawa )/amoire*at(3,3)*alat * grid_factor_track(ig)
+            fac(ig) = e2*tpi/( sqrt(qq) + yukawa )*at(3,3)*alat * grid_factor_track(ig)
             else
             fac(ig) = e2*fpi/( qq + yukawa ) * grid_factor_track(ig) ! as HARTREE
             endif ! lmoire

--- a/PW/src/exx_base.f90
+++ b/PW/src/exx_base.f90
@@ -723,7 +723,6 @@ MODULE exx_base
     USE constants,  ONLY : fpi, e2, pi, tpi, eps8
     USE constants,  ONLY : BOHR_RADIUS_ANGS
     USE moire,      ONLY : lmoire, amoire
-    USE input_parameters, ONLY: epsmoire
     !
     IMPLICIT NONE
     !
@@ -816,7 +815,7 @@ MODULE exx_base
          ELSE
             if (lmoire) then
             if (abs(g(3,ig)) > eps8) cycle
-            fac(ig) = e2*tpi/( sqrt(qq) + yukawa )/amoire/epsmoire*at(3,3)*alat * grid_factor_track(ig)
+            fac(ig) = e2*tpi/( sqrt(qq) + yukawa )/amoire*at(3,3)*alat * grid_factor_track(ig)
             else
             fac(ig) = e2*fpi/( qq + yukawa ) * grid_factor_track(ig) ! as HARTREE
             endif ! lmoire

--- a/PW/src/g2_kin.f90
+++ b/PW/src/g2_kin.f90
@@ -19,8 +19,8 @@ SUBROUTINE g2_kin( ik )
   USE gvecw,                ONLY : ecfixed, qcutz, q2sigma
   USE wvfct,                ONLY : g2kin
   USE wvfct_gpum,           ONLY : using_g2kin
-  USE constants,            ONLY : BOHR_RADIUS_ANGS
   USE moire,                ONLY : lmoire, amoire
+  USE input_parameters,     ONLY : mstar
   !
   IMPLICIT NONE
   !
@@ -32,7 +32,7 @@ SUBROUTINE g2_kin( ik )
   REAL(DP) :: k2pre
   !
   if (lmoire) then
-    k2pre = tpiba2/amoire/amoire
+    k2pre = tpiba2/amoire/amoire/mstar
   else
     k2pre = tpiba2
   endif

--- a/PW/src/g2_kin.f90
+++ b/PW/src/g2_kin.f90
@@ -19,7 +19,6 @@ SUBROUTINE g2_kin( ik )
   USE gvecw,                ONLY : ecfixed, qcutz, q2sigma
   USE wvfct,                ONLY : g2kin
   USE wvfct_gpum,           ONLY : using_g2kin
-  USE moire,                ONLY : lmoire, amoire
   !
   IMPLICIT NONE
   !
@@ -28,18 +27,12 @@ SUBROUTINE g2_kin( ik )
   ! ... local variables
   !
   INTEGER :: ig, npw
-  REAL(DP) :: k2pre
   !
-  if (lmoire) then
-    k2pre = tpiba2/amoire/amoire
-  else
-    k2pre = tpiba2
-  endif
   CALL using_g2kin(1)
   npw = ngk(ik)
   g2kin(1:npw) = ( ( xk(1,ik) + g(1,igk_k(1:npw,ik)) )**2 + &
                    ( xk(2,ik) + g(2,igk_k(1:npw,ik)) )**2 + &
-                   ( xk(3,ik) + g(3,igk_k(1:npw,ik)) )**2 ) * k2pre
+                   ( xk(3,ik) + g(3,igk_k(1:npw,ik)) )**2 ) * tpiba2
   !
   IF ( qcutz > 0.D0 ) THEN
      !

--- a/PW/src/g2_kin.f90
+++ b/PW/src/g2_kin.f90
@@ -20,7 +20,6 @@ SUBROUTINE g2_kin( ik )
   USE wvfct,                ONLY : g2kin
   USE wvfct_gpum,           ONLY : using_g2kin
   USE moire,                ONLY : lmoire, amoire
-  USE input_parameters,     ONLY : mstar
   !
   IMPLICIT NONE
   !
@@ -32,7 +31,7 @@ SUBROUTINE g2_kin( ik )
   REAL(DP) :: k2pre
   !
   if (lmoire) then
-    k2pre = tpiba2/amoire/amoire/mstar
+    k2pre = tpiba2/amoire/amoire
   else
     k2pre = tpiba2
   endif

--- a/PW/src/g2_kin_gpu.f90
+++ b/PW/src/g2_kin_gpu.f90
@@ -18,8 +18,8 @@ SUBROUTINE g2_kin_gpu ( ik )
   USE klist,                ONLY : xk, ngk, igk_k_d
   USE gvect,                ONLY : g_d
   USE wvfct_gpum,           ONLY : g2kin_d, using_g2kin_d
-  USE constants,            ONLY : BOHR_RADIUS_ANGS
   USE moire,                ONLY : lmoire, amoire
+  USE input_parameters,     ONLY : mstar
   !
   IMPLICIT NONE
   !
@@ -32,7 +32,7 @@ SUBROUTINE g2_kin_gpu ( ik )
   REAL(DP):: k2pre
   !
   if (lmoire) then
-    k2pre = tpiba2/amoire/amoire
+    k2pre = tpiba2/amoire/amoire/mstar
   else
     k2pre = tpiba2
   endif

--- a/PW/src/g2_kin_gpu.f90
+++ b/PW/src/g2_kin_gpu.f90
@@ -19,7 +19,6 @@ SUBROUTINE g2_kin_gpu ( ik )
   USE gvect,                ONLY : g_d
   USE wvfct_gpum,           ONLY : g2kin_d, using_g2kin_d
   USE moire,                ONLY : lmoire, amoire
-  USE input_parameters,     ONLY : mstar
   !
   IMPLICIT NONE
   !
@@ -32,7 +31,7 @@ SUBROUTINE g2_kin_gpu ( ik )
   REAL(DP):: k2pre
   !
   if (lmoire) then
-    k2pre = tpiba2/amoire/amoire/mstar
+    k2pre = tpiba2/amoire/amoire
   else
     k2pre = tpiba2
   endif

--- a/PW/src/g2_kin_gpu.f90
+++ b/PW/src/g2_kin_gpu.f90
@@ -18,7 +18,6 @@ SUBROUTINE g2_kin_gpu ( ik )
   USE klist,                ONLY : xk, ngk, igk_k_d
   USE gvect,                ONLY : g_d
   USE wvfct_gpum,           ONLY : g2kin_d, using_g2kin_d
-  USE moire,                ONLY : lmoire, amoire
   !
   IMPLICIT NONE
   !
@@ -28,13 +27,7 @@ SUBROUTINE g2_kin_gpu ( ik )
   !
   INTEGER :: ig, npw,i
   REAL(DP):: xk1,xk2,xk3
-  REAL(DP):: k2pre
   !
-  if (lmoire) then
-    k2pre = tpiba2/amoire/amoire
-  else
-    k2pre = tpiba2
-  endif
   CALL using_g2kin_d(2)
   !
   npw = ngk(ik)
@@ -47,7 +40,7 @@ SUBROUTINE g2_kin_gpu ( ik )
   DO i=1,npw
      g2kin_d(i) = ( ( xk1 + g_d(1,igk_k_d(i,ik)) )*( xk1 + g_d(1,igk_k_d(i,ik)) ) + &
                   ( xk2 + g_d(2,igk_k_d(i,ik)) )*( xk2 + g_d(2,igk_k_d(i,ik)) ) + &
-                  ( xk3 + g_d(3,igk_k_d(i,ik)) )*( xk3 + g_d(3,igk_k_d(i,ik)) ) ) * k2pre
+                  ( xk3 + g_d(3,igk_k_d(i,ik)) )*( xk3 + g_d(3,igk_k_d(i,ik)) ) ) * tpiba2
   !
   END DO
   !

--- a/PW/src/h_psi.f90
+++ b/PW/src/h_psi.f90
@@ -103,6 +103,7 @@ SUBROUTINE h_psi_( lda, n, m, psi, hpsi )
   USE fft_base,                ONLY: dffts
   USE exx,                     ONLY: use_ace, vexx, vexxace_gamma, vexxace_k
   USE xc_lib,                  ONLY: exx_is_active, xclib_dft_is
+  USE input_parameters,        ONLY: lob
   USE fft_helper_subroutines
   !
   USE wvfct_gpum,              ONLY: using_g2kin
@@ -257,7 +258,7 @@ SUBROUTINE h_psi_( lda, n, m, psi, hpsi )
   !
   ! ... Here the exact-exchange term Vxx psi
   !
-  IF ( exx_is_active() ) THEN
+  IF ( .not.lob .and. exx_is_active() ) THEN
      IF ( use_ace ) THEN
         IF ( gamma_only ) THEN
            CALL vexxace_gamma( lda, m, psi, ee, hpsi )

--- a/PW/src/input.f90
+++ b/PW/src/input.f90
@@ -685,9 +685,9 @@ SUBROUTINE iosys()
     vmoire_ = vmoire_in_mev*1e-3/autoev*e2 ! in Ry
     pmoire_ = pmoire_in_deg/180.d0*pi
     ! change energy unit
-    !eha_ = mstar/epsmoire/epsmoire
-    !amoire_ = amoire_*mstar/epsmoire ! effetive bohr
-    !vmoire_ = vmoire_/eha_ ! effetive Ry
+    eha_ = mstar/epsmoire/epsmoire
+    amoire_ = amoire_*mstar/epsmoire ! effetive bohr
+    vmoire_ = vmoire_/eha_ ! effetive Ry
   endif ! lmoire
   !
   ! NONCOLLINEAR MAGNETISM, MAGNETIC CONSTRAINTS

--- a/PW/src/input.f90
+++ b/PW/src/input.f90
@@ -682,11 +682,12 @@ SUBROUTINE iosys()
   lmoire_ = lmoire
   if (lmoire) THEN
     amoire_ = amoire_in_ang/bohr_radius_angs ! in bohr
-    amoire_ = amoire_*mstar/epsmoire ! effetive bohr
-    eha_ = mstar/epsmoire/epsmoire
     vmoire_ = vmoire_in_mev*1e-3/autoev*e2 ! in Ry
-    vmoire_ = vmoire_/eha_ ! effetive Ry
     pmoire_ = pmoire_in_deg/180.d0*pi
+    ! change energy unit
+    !eha_ = mstar/epsmoire/epsmoire
+    !amoire_ = amoire_*mstar/epsmoire ! effetive bohr
+    !vmoire_ = vmoire_/eha_ ! effetive Ry
   endif ! lmoire
   !
   ! NONCOLLINEAR MAGNETISM, MAGNETIC CONSTRAINTS

--- a/PW/src/set_vrs.f90
+++ b/PW/src/set_vrs.f90
@@ -49,6 +49,7 @@ SUBROUTINE sum_vrs( nrxx, nspin, vltot, vr, vrs )
   !! Accumulates local potential contributions into vrs (the total local potential).
   !
   USE kinds
+  USE input_parameters, ONLY : lob
   !
   IMPLICIT NONE
   !
@@ -77,9 +78,10 @@ SUBROUTINE sum_vrs( nrxx, nspin, vltot, vr, vrs )
         !
         ! noncolinear case: only the first component contains vltot
         !
-        vrs(:,is) = vr(:,is)
+        if (.not.lob) vrs(:,is) = vr(:,is)
      ELSE
-        vrs(:,is) = vltot(:) + vr(:,is)
+        vrs(:,is) = vltot(:)
+        if (.not.lob) vrs(:,is) = vrs(:, is) + vr(:,is)
      ENDIF
      !
   ENDDO

--- a/PW/src/setlocal.f90
+++ b/PW/src/setlocal.f90
@@ -171,8 +171,9 @@ SUBROUTINE setlocal
 END SUBROUTINE setlocal
 
 subroutine hex_shell(g6_out)
-  USE constants,         ONLY : eps8, pi, tpi
+  USE constants,         ONLY : eps6, eps8, pi, tpi
   USE cell_base,         ONLY : bg, tpiba
+  USE moire,             ONLY : amoire
   implicit none
   double precision, intent(out) :: g6_out(3,6)
   double precision :: g1(3), g6(3,6), angles(6), bmag
@@ -180,19 +181,19 @@ subroutine hex_shell(g6_out)
   integer iangs(6), ih, ib1, ib2
   g6_out(:,:) = 0.d0
 
-  ! hard-code ibrav=4 with alat=1
+  ! hard-code ibrav=4 with alat=amoire
   raxes(1,1) = 1.d0
   raxes(2,1) = 1.d0/sqrt(3.d0)
   raxes(1,2) = 0.d0
   raxes(2,2) = 2.d0/sqrt(3.d0)
-  raxes(:,:) = tpi*raxes(:,:)
+  raxes(:,:) = tpi/amoire*raxes(:,:)
   bmag = raxes(2, 2)
   ! check that raxes is related to bg by an integer tile matrix
   tmat = transpose(matmul(matinv2(tpiba*bg(1:2,1:2)), raxes))
   do ib1=1,2
   do ib2=1,2
-    if (abs(tmat(ib1,ib2)-nint(tmat(ib1,ib2))) > eps8) then
-      call errore('hex_shell', 'supercell is not tiled from ibrav=4 alat=1')
+    if (abs(tmat(ib1,ib2)-nint(tmat(ib1,ib2))) > eps6) then
+      call errore('hex_shell', 'supercell is not tiled from ibrav=4 alat=amoire', 1)
     endif
   enddo
   enddo

--- a/PW/src/v_of_rho.f90
+++ b/PW/src/v_of_rho.f90
@@ -524,7 +524,7 @@ SUBROUTINE v_h( rhog, ehart, charge, v )
   USE martyna_tuckerman, ONLY : wg_corr_h, do_comp_mt
   USE esm,               ONLY : do_comp_esm, esm_hartree, esm_bc
   USE Coul_cut_2D,       ONLY : do_cutoff_2D, cutoff_2D, cutoff_hartree  
-  USE moire,             ONLY : lmoire, amoire
+  USE moire,             ONLY : lmoire
   !
   IMPLICIT NONE
   !
@@ -597,7 +597,7 @@ SUBROUTINE v_h( rhog, ehart, charge, v )
      ENDIF
      !
      if (lmoire) then
-     fac = e2 * tpi / tpiba / amoire * at(3, 3)*alat
+     fac = e2 * tpi / tpiba * at(3, 3)*alat
      else
      fac = e2 * fpi / tpiba2
      endif ! lmoire

--- a/PW/src/v_of_rho.f90
+++ b/PW/src/v_of_rho.f90
@@ -525,7 +525,6 @@ SUBROUTINE v_h( rhog, ehart, charge, v )
   USE esm,               ONLY : do_comp_esm, esm_hartree, esm_bc
   USE Coul_cut_2D,       ONLY : do_cutoff_2D, cutoff_2D, cutoff_hartree  
   USE moire,             ONLY : lmoire, amoire
-  USE input_parameters,  ONLY : epsmoire
   !
   IMPLICIT NONE
   !
@@ -598,7 +597,7 @@ SUBROUTINE v_h( rhog, ehart, charge, v )
      ENDIF
      !
      if (lmoire) then
-     fac = e2 * tpi / tpiba / amoire/epsmoire * at(3, 3)*alat
+     fac = e2 * tpi / tpiba / amoire * at(3, 3)*alat
      else
      fac = e2 * fpi / tpiba2
      endif ! lmoire

--- a/PW/src/v_of_rho.f90
+++ b/PW/src/v_of_rho.f90
@@ -525,6 +525,7 @@ SUBROUTINE v_h( rhog, ehart, charge, v )
   USE esm,               ONLY : do_comp_esm, esm_hartree, esm_bc
   USE Coul_cut_2D,       ONLY : do_cutoff_2D, cutoff_2D, cutoff_hartree  
   USE moire,             ONLY : lmoire, amoire
+  USE input_parameters,  ONLY : epsmoire
   !
   IMPLICIT NONE
   !
@@ -597,7 +598,7 @@ SUBROUTINE v_h( rhog, ehart, charge, v )
      ENDIF
      !
      if (lmoire) then
-     fac = e2 * tpi / tpiba / amoire * at(3, 3)*alat
+     fac = e2 * tpi / tpiba / amoire/epsmoire * at(3, 3)*alat
      else
      fac = e2 * fpi / tpiba2
      endif ! lmoire

--- a/PostHF/src/onebody_hamiltonian.f90
+++ b/PostHF/src/onebody_hamiltonian.f90
@@ -57,7 +57,7 @@ MODULE onebody_hamiltonian
     COMPLEX(DP) :: ctemp
     INTEGER :: ia, ib, i0, no, error, npw,npw2
     INTEGER :: ik,ibnd, ikk, ispin
-    REAL(DP) :: fac, wm
+    REAL(DP) :: fac
     COMPLEX(DP) :: CONE, CZERO, CNORM
     COMPLEX(DP), ALLOCATABLE :: Orbitals(:,:) 
     COMPLEX(DP), ALLOCATABLE :: H1(:,:)
@@ -65,11 +65,6 @@ MODULE onebody_hamiltonian
     COMPLEX(DP), ALLOCATABLE :: spsi(:,:)
     COMPLEX(DP), ALLOCATABLE :: evc_(:,:)
     !
-    if (lmoire) then
-      wm = 1.d0/amoire/amoire
-    else ! default band width
-      wm = 1.d0
-    endif
 
     CONE = (1.d0,0.d0)
     CZERO = (0.d0,0.d0)
@@ -118,8 +113,8 @@ MODULE onebody_hamiltonian
       !
       hpsi(:,:) = (0.d0,0.d0)  
       DO ibnd = 1, h5id_orbs%norbK(ik)
-        hpsi (1:npw, ibnd) = wm*tpiba2 * g2kin (1:npw) * Orbitals(1:npw,ibnd) 
-        if(noncolin) hpsi (npwx+1:npwx+npw, ibnd+h5id_orbs%norbK(ik)) = wm*tpiba2 * &
+        hpsi (1:npw, ibnd) = tpiba2 * g2kin (1:npw) * Orbitals(1:npw,ibnd) 
+        if(noncolin) hpsi (npwx+1:npwx+npw, ibnd+h5id_orbs%norbK(ik)) = tpiba2 * &
                                                 g2kin (1:npw) * Orbitals(1:npw,ibnd)
       END DO
       !

--- a/PostHF/src/posthf.f90
+++ b/PostHF/src/posthf.f90
@@ -142,11 +142,12 @@ PROGRAM posthf
   lmoire_ = lmoire
   if (lmoire) THEN
     amoire_ = amoire_in_ang/bohr_radius_angs ! in bohr
-    amoire_ = amoire_*mstar/epsmoire ! effetive bohr
-    eha_ = mstar/epsmoire/epsmoire
-    vmoire_ = vmoire_in_mev*1e-3/autoev  ! in ha
-    vmoire_ = vmoire_/eha_ ! effetive ha
+    vmoire_ = vmoire_in_mev*1e-3/autoev*e2 ! in Ry
     pmoire_ = pmoire_in_deg/180.d0*pi
+    ! change energy unit
+    eha_ = mstar/epsmoire/epsmoire
+    amoire_ = amoire_*mstar/epsmoire ! effetive bohr
+    vmoire_ = vmoire_/eha_ ! effetive Ry
   endif ! lmoire
   !
   ! MAM: Problematic situation, I need to modify qnorm before init_us_1 is 

--- a/PostHF/src/pp_utilities.f90
+++ b/PostHF/src/pp_utilities.f90
@@ -19,7 +19,7 @@ SUBROUTINE g2_convolution(ngm, g, xk, xkq, fac)
   USE coulomb_vcut_module,  ONLY: vcut_get,  vcut_spheric_get
   USE posthf_mod, ONLY:  use_coulomb_vcut_ws, use_coulomb_vcut_spheric, &
                 vcut, exxdiv
-  USE moire, ONLY: lmoire, amoire
+  USE moire, ONLY: lmoire
   !
   IMPLICIT NONE
   !
@@ -67,7 +67,7 @@ SUBROUTINE g2_convolution(ngm, g, xk, xkq, fac)
           if (abs(g(3,ig)) > eps8) then
             fac(ig) = 0.d0
           else
-            fac(ig) = e2*tpi/sqrt(qq)/amoire*at(3,3)*alat
+            fac(ig) = e2*tpi/sqrt(qq)*at(3,3)*alat
           endif
         else
           fac(ig)=e2*fpi/qq


### PR DESCRIPTION
Length unit is now a_B^* = a_B * eps/m*
Energy unit is now E_h^* = E_h * m*/eps^2

I also added a somewhat intrusive flag `lob` to turn off `vr` contribution in set_vrs.
The idea is to have `lob=T` correspond to one-body run without any xc contribution.
Unfortunately, `lob=T` does not work correctly when exact exchange is turned on ...