### PR TITLE
add option to include Madlung energy

### DIFF
--- a/Modules/CMakeLists.txt
+++ b/Modules/CMakeLists.txt
@@ -110,6 +110,7 @@ set(src_modules
     radial_gradients.f90 
     rgen.f90 
     recips.f90 
+    madelung.f90
     remove_tot_torque.f90
     set_hubbard_l.f90 
     set_hubbard_n.f90 

--- a/Modules/input_parameters.f90
+++ b/Modules/input_parameters.f90
@@ -637,6 +637,9 @@ MODULE input_parameters
         LOGICAL :: lmoire = .false.
         !! Use 2D moire potential
         !
+        LOGICAL :: lmadelung = .false.
+        !! Use Madelung correction to exxdiv
+        !
         ! the following are the needed parameters for 2D moire potential
         REAL(DP) :: amoire_in_ang = BOHR_RADIUS_ANGS
         !! moire lattice constant in Angstrom
@@ -698,7 +701,7 @@ MODULE input_parameters
              space_group, uniqueb, origin_choice, rhombohedral,               &
              zgate, relaxz, block, block_1, block_2, block_height,            &
              lmoire, amoire_in_ang, vmoire_in_mev, pmoire_in_deg, mstar,      &
-             epsmoire, vh_scale, vx_scale, no_constrain_type
+             epsmoire, vh_scale, vx_scale, no_constrain_type, lmadelung
 
 !=----------------------------------------------------------------------------=!
 !  ELECTRONS Namelist Input Parameters

--- a/Modules/madelung.f90
+++ b/Modules/madelung.f90
@@ -1,0 +1,117 @@
+module madelung
+  use kinds, only: dp
+  use constants, only: pi
+  implicit none
+  real(dp) :: volume, alpha
+  integer :: ndim
+contains
+
+  subroutine madelung_init(alat, at, ndim_in)
+    real(dp), intent(in) :: alat, at(3,3)
+    integer, intent(in) :: ndim_in
+    alpha = 2.0d0/alat
+    ndim = ndim_in
+    if ((ndim .ne. 2).and.(ndim .ne. 3)) then
+      call errore('madelung_sum', 'unknown ndim', ndim)
+    endif
+    volume = alat**ndim*det(at(:ndim,:ndim),ndim)
+  end subroutine
+
+  pure function madelung_sum(alat, at, bg) result(vmad)
+    real(dp), intent(in) :: alat, at(3,3), bg(3,3)
+    real(dp) :: vmad
+    ! local
+    real(dp) :: r(3), rmag, blat
+    real(dp) :: esr, elr, vlr_r0, vsr_k0
+    integer :: i, j, k, mx, my, mz
+    integer :: nr, nk
+
+    !!!! hard-code number of lattices to sum over
+    nr = 5
+    nk = 5
+
+    ! constants
+    vlr_r0 = 2.d0*alpha/sqrt(pi)
+    if (ndim.eq.2) then
+      vsr_k0 = 2.d0*sqrt(pi)/alpha/volume
+    else if (ndim.eq.3) then
+      vsr_k0 = pi/(alpha*alpha)/volume
+    end if
+
+    ! sums
+    ! short-range
+    esr = 0.d0
+    mx = nr; my = nr; mz = nr
+    if (ndim.eq.2) mz=0
+    do concurrent (i=-mx:mx, j=-my:my, k=-mz:mz)
+      if ((i.eq.0).and.(j.eq.0).and.(k.eq.0)) cycle
+      r = i*at(:,1)+j*at(:,2)+k*at(:,3)
+      rmag = alat*sqrt(dot_product(r, r))
+      esr = esr + vsr_r(rmag)
+    enddo
+    esr = 0.5*esr
+    ! long-range
+    blat = 2*pi/alat
+    elr = 0.d0
+    mx = nk; my = nk; mz = nk
+    if (ndim.eq.2) mz=0
+    do concurrent (i=-mx:mx, j=-my:my, k=-mz:mz)
+      if ((i.eq.0).and.(j.eq.0).and.(k.eq.0)) cycle
+      r = i*bg(:,1)+j*bg(:,2)+k*bg(:,3)
+      rmag = blat*sqrt(dot_product(r, r))
+      if (ndim.eq.2) then
+        elr = elr + vlr_k_2d(rmag)
+      else if (ndim.eq.3) then
+        elr = elr + vlr_k_3d(rmag)
+      endif
+    enddo
+    elr = 0.5*elr
+
+    ! assemble
+    vmad = esr + elr -0.5*(vlr_r0+vsr_k0)
+  end function madelung_sum
+
+  pure function vlr_k_2d(k) result(val)
+    real(dp), intent(in) :: k
+    real(dp) :: val
+    val = 2*pi/k*erfc(k/(2*alpha))/volume
+  end function vlr_k_2d
+
+  pure function vlr_k_3d(k) result(val)
+    real(dp), intent(in) :: k
+    real(dp) :: val
+    ! local
+    real(dp) :: k2, b2
+    k2 = k*k
+    b2 = (2*alpha)*(2*alpha)
+    val = 4*pi/k2*exp(-k2/b2)/volume
+  end function vlr_k_3d
+
+  pure function vsr_r(r) result(val)
+    real (dp), intent(in) :: r
+    real(dp) :: val
+    val = erfc(alpha*r)/r
+  end function vsr_r
+
+  recursive pure function det(a, n) result(acc)
+    ! https://rosettacode.org/wiki/Determinant_and_permanent#Fortran
+    integer, intent(in) :: n
+    real(dp), dimension(n,n), intent(in) :: a(:,:)
+    real(dp), dimension(n-1,n-1) :: b
+    real(dp) :: acc
+    ! local variables
+    integer :: i, sgn
+    if (n .eq. 1) then
+      acc = a(1,1)
+    else
+      acc = 0
+      sgn = 1
+      do i=1, n
+        b(:, :(i-1)) = a(2:, :i-1)
+        b(:, i:) = a(2:, i+1:)
+        acc = acc + sgn * a(1, i) * det(b, n-1)
+        sgn = -1 * sgn
+      enddo
+    endif
+  end function det
+end module madelung

--- a/Modules/read_namelists.f90
+++ b/Modules/read_namelists.f90
@@ -853,6 +853,7 @@ MODULE read_namelists_module
        CALL mp_bcast( vh_scale,          ionode_id, intra_image_comm )
        CALL mp_bcast( vx_scale,          ionode_id, intra_image_comm )
        CALL mp_bcast( no_constrain_type, ionode_id, intra_image_comm )
+       CALL mp_bcast( lmadelung,         ionode_id, intra_image_comm )
 
        ! ... EXX
 

--- a/PW/src/electrons.f90
+++ b/PW/src/electrons.f90
@@ -466,6 +466,7 @@ SUBROUTINE electrons_scf ( printout, exxen )
   USE input_parameters,     ONLY : lmoire
   USE madelung,             ONLY : madelung_init, madelung_sum
   USE constants,            ONLY : e2
+  USE start_k,              ONLY : nk1, nk2, nk3
   !
   IMPLICIT NONE
   !
@@ -519,6 +520,7 @@ SUBROUTINE electrons_scf ( printout, exxen )
   REAL(DP) :: vmad
   INTEGER :: ndim
   LOGICAL :: lmadelung
+  real(dp) :: at1(3,3), bg1(3,3)
   !! auxiliary variables for grimme-d3
   INTEGER:: atnum(1:nat), na
   !! auxiliary variables for grimme-d3
@@ -562,8 +564,21 @@ SUBROUTINE electrons_scf ( printout, exxen )
   endif ! lmoire
   lmadelung = .true.
   if (lmadelung) then
-    call madelung_init(alat, at, ndim)
-    vmad = e2*madelung_sum(alat, at, bg)
+    if (nkstot.eq.1) then
+      nk1 = 1
+      nk2 = 1
+      nk3 = 1
+    else if ((nk1*nk2*nk3).eq.0) then
+      call errore('electrons_scf', 'Must use auto kgrid for madelung correction', 1)
+    endif
+    at1(:,1) = at(:,1)*nk1
+    at1(:,2) = at(:,2)*nk2
+    at1(:,3) = at(:,3)*nk3
+    bg1(:,1) = bg(:,1)/nk1
+    bg1(:,2) = bg(:,2)/nk2
+    bg1(:,3) = bg(:,3)/nk3
+    call madelung_init(alat, at1, ndim)
+    vmad = e2*madelung_sum(alat, at1, bg1)
     ewld = ewld + vmad
   end if ! lmadelung
   !

--- a/PW/src/electrons.f90
+++ b/PW/src/electrons.f90
@@ -463,7 +463,7 @@ SUBROUTINE electrons_scf ( printout, exxen )
   USE wvfct_gpum,           ONLY : using_et
   USE scf_gpum,             ONLY : using_vrs
   USE device_fbuff_m,             ONLY : dev_buf, pin_buf
-  USE input_parameters,     ONLY : lmoire
+  USE input_parameters,     ONLY : lmoire, lmadelung
   USE madelung,             ONLY : madelung_init, madelung_sum
   USE constants,            ONLY : e2
   USE start_k,              ONLY : nk1, nk2, nk3
@@ -519,7 +519,6 @@ SUBROUTINE electrons_scf ( printout, exxen )
   REAL(DP) :: latvecs(3,3)
   REAL(DP) :: vmad
   INTEGER :: ndim
-  LOGICAL :: lmadelung
   real(dp) :: at1(3,3), bg1(3,3)
   !! auxiliary variables for grimme-d3
   INTEGER:: atnum(1:nat), na
@@ -562,7 +561,6 @@ SUBROUTINE electrons_scf ( printout, exxen )
                 omega, g, gg, ngm, gcutm, gstart, gamma_only, strf )
   ENDIF
   endif ! lmoire
-  lmadelung = .true.
   if (lmadelung) then
     if (nkstot.eq.1) then
       nk1 = 1
@@ -579,6 +577,7 @@ SUBROUTINE electrons_scf ( printout, exxen )
     bg1(:,3) = bg(:,3)/nk3
     call madelung_init(alat, at1, ndim)
     vmad = e2*madelung_sum(alat, at1, bg1)
+    write(stdout, 8999) vmad, ewld
     ewld = ewld + vmad
   end if ! lmadelung
   !
@@ -1144,6 +1143,7 @@ SUBROUTINE electrons_scf ( printout, exxen )
 9101 FORMAT(/'     End of self-consistent calculation' )
 9110 FORMAT(/'     convergence has been achieved in ',i3,' iterations' )
 9120 FORMAT(/'     convergence NOT achieved after ',i3,' iterations: stopping' )
+8999 FORMAT(/'     Adding Madelung constant',F15.8,' to Ewald ',F15.8)
   !
   CONTAINS
      !

--- a/PW/src/electrons.f90
+++ b/PW/src/electrons.f90
@@ -577,8 +577,8 @@ SUBROUTINE electrons_scf ( printout, exxen )
     bg1(:,3) = bg(:,3)/nk3
     call madelung_init(alat, at1, ndim)
     vmad = e2*madelung_sum(alat, at1, bg1)
-    write(stdout, 8999) vmad, ewld
-    ewld = ewld + vmad
+    write(stdout, 8999) nelec, vmad, ewld
+    ewld = ewld + vmad*nelec
   end if ! lmadelung
   !
   IF ( llondon ) THEN
@@ -1143,7 +1143,7 @@ SUBROUTINE electrons_scf ( printout, exxen )
 9101 FORMAT(/'     End of self-consistent calculation' )
 9110 FORMAT(/'     convergence has been achieved in ',i3,' iterations' )
 9120 FORMAT(/'     convergence NOT achieved after ',i3,' iterations: stopping' )
-8999 FORMAT(/'     Adding Madelung constant',F15.8,' to Ewald ',F15.8)
+8999 FORMAT(/'     Adding N=',F5.2,' times Madelung constant',F15.8,' to Ewald ',F15.8)
   !
   CONTAINS
      !

--- a/PW/src/electrons.f90
+++ b/PW/src/electrons.f90
@@ -464,6 +464,8 @@ SUBROUTINE electrons_scf ( printout, exxen )
   USE scf_gpum,             ONLY : using_vrs
   USE device_fbuff_m,             ONLY : dev_buf, pin_buf
   USE input_parameters,     ONLY : lmoire
+  USE madelung,             ONLY : madelung_init, madelung_sum
+  USE constants,            ONLY : e2
   !
   IMPLICIT NONE
   !
@@ -514,6 +516,9 @@ SUBROUTINE electrons_scf ( printout, exxen )
   REAL(DP) :: etot_cmp_paw(nat,2,2)
   ! 
   REAL(DP) :: latvecs(3,3)
+  REAL(DP) :: vmad
+  INTEGER :: ndim
+  LOGICAL :: lmadelung
   !! auxiliary variables for grimme-d3
   INTEGER:: atnum(1:nat), na
   !! auxiliary variables for grimme-d3
@@ -545,7 +550,9 @@ SUBROUTINE electrons_scf ( printout, exxen )
   !
   if (lmoire) then
    ewld = 0.d0
+   ndim = 2
   else
+   ndim = 3
   IF ( do_comp_esm ) THEN
      ewld = esm_ewald()
   ELSE
@@ -553,6 +560,12 @@ SUBROUTINE electrons_scf ( printout, exxen )
                 omega, g, gg, ngm, gcutm, gstart, gamma_only, strf )
   ENDIF
   endif ! lmoire
+  lmadelung = .true.
+  if (lmadelung) then
+    call madelung_init(alat, at, ndim)
+    vmad = e2*madelung_sum(alat, at, bg)
+    ewld = ewld + vmad
+  end if ! lmadelung
   !
   IF ( llondon ) THEN
      elondon = energy_london( alat , nat , ityp , at ,bg , tau )


### PR DESCRIPTION
`lmadelung = .true.` calculates the Madelung energy (the interaction of an electron with its own periodic images).
```
input_dft='hf'
```
and
```
 input_dft='hf'
 exxdiv_treatment = 'none'
 x_gamma_extrapolation = .false.
 lmadelung = .true.
```
should converge to the same thermodynamic limit.