### PR TITLE
Allow converter to change occupation from input

### DIFF
--- a/PostHF/CMakeLists.txt
+++ b/PostHF/CMakeLists.txt
@@ -3,6 +3,7 @@ set(src_posthf
     src/read_orbitals_from_file.f90
     src/twobody_hamiltonian.f90
     src/orbital_generators.f90
+    src/iocc.f90
     src/onebody_hamiltonian.f90
     src/mp2_module.f90
     src/rpa_module.f90

--- a/PostHF/src/iocc.f90
+++ b/PostHF/src/iocc.f90
@@ -1,6 +1,5 @@
 module iocc
   use kinds, only : dp
-  USE wvfct, ONLY: et
   implicit none
   private
 
@@ -32,6 +31,7 @@ contains
     integer :: i, j
     real(dp) :: tol, ai
     logical :: found
+    integer :: idx(n)
     tol = 1e-6 ! hard-code tolerance
     m = 0
     au(:) = 0
@@ -49,15 +49,20 @@ contains
         au(m) = ai
       endif
     enddo
-    call quicksort(au, 1, m)
+    do i=1,m
+      idx(i) = i
+    enddo
+    call quicksort(au, 1, m, idx)
   end subroutine unique
 
-  recursive subroutine quicksort(a, first, last)
+  recursive subroutine quicksort(a, first, last, idx)
     real(dp), intent(inout) :: a(:)
     integer, intent(in) :: first, last
+    integer, intent(inout), optional :: idx(:)
     ! local
-    integer i, j
+    integer :: i, j
     real(dp) :: x, t
+    integer :: k
   
     x = a( (first+last) / 2 )
     i = first
@@ -71,14 +76,22 @@ contains
        end do
        if (i >= j) exit
        t = a(i);  a(i) = a(j);  a(j) = t
+       if (present(idx)) then
+         k = idx(i); idx(i) = idx(j); idx(j) = k
+       endif
        i=i+1
        j=j-1
     end do
+    if (present(idx)) then
+    if (first < i-1) call quicksort(a, first, i-1, idx)
+    if (j+1 < last)  call quicksort(a, j+1, last, idx)
+    else ! no idx
     if (first < i-1) call quicksort(a, first, i-1)
     if (j+1 < last)  call quicksort(a, j+1, last)
+    endif ! present(idx)
   end subroutine quicksort
 
-  function n_of_mu(mxmu, mus, etv) result(nmu)
+  pure function n_of_mu(mxmu, mus, etv) result(nmu)
     real(dp) :: nmu(mxmu)
     integer, intent(in) :: mxmu
     real(dp), intent(in) :: mus(mxmu)

--- a/PostHF/src/iocc.f90
+++ b/PostHF/src/iocc.f90
@@ -1,0 +1,99 @@
+module iocc
+  use kinds, only : dp
+  USE wvfct, ONLY: et
+  implicit none
+  private
+
+  public :: fill_bands, n_of_mu
+  public :: unique
+
+contains
+
+  pure integer function fill_bands(et, mu) result(nmu)
+    real(dp), intent(in) :: et(:,:), mu
+    ! local
+    integer :: ib, ik, nb, nk
+    nb = size(et, 1)
+    nk = size(et, 2)
+    nmu = 0
+    do ik=1,nk
+      do ib=1,nb
+        if (et(ib,ik) <= mu) nmu = nmu+1
+      enddo
+    enddo
+  end function fill_bands
+
+  subroutine unique(n, a, m, au)
+    integer, intent(in) :: n
+    real(dp), intent(in) :: a(n)
+    integer, intent(out) :: m
+    real(dp), intent(out) :: au(n)
+    ! local
+    integer :: i, j
+    real(dp) :: tol, ai
+    logical :: found
+    tol = 1e-6 ! hard-code tolerance
+    m = 0
+    au(:) = 0
+    do i=1,n
+      ai = a(i)
+      found = .false.
+      do j=1,m
+        if (abs(ai-au(j)) < tol) then
+          found = .true.
+          exit
+        endif
+      enddo
+      if (.not.found) then
+        m = m+1
+        au(m) = ai
+      endif
+    enddo
+    call quicksort(au, 1, m)
+  end subroutine unique
+
+  recursive subroutine quicksort(a, first, last)
+    real(dp), intent(inout) :: a(:)
+    integer, intent(in) :: first, last
+    ! local
+    integer i, j
+    real(dp) :: x, t
+  
+    x = a( (first+last) / 2 )
+    i = first
+    j = last
+    do
+       do while (a(i) < x)
+          i=i+1
+       end do
+       do while (x < a(j))
+          j=j-1
+       end do
+       if (i >= j) exit
+       t = a(i);  a(i) = a(j);  a(j) = t
+       i=i+1
+       j=j-1
+    end do
+    if (first < i-1) call quicksort(a, first, i-1)
+    if (j+1 < last)  call quicksort(a, j+1, last)
+  end subroutine quicksort
+
+  function n_of_mu(mxmu, mus, etv) result(nmu)
+    real(dp) :: nmu(mxmu)
+    integer, intent(in) :: mxmu
+    real(dp), intent(in) :: mus(mxmu)
+    real(dp), intent(in) :: etv(:)
+    ! local
+    integer :: ib, nb, imu
+    real(dp) :: e1
+    nb = size(etv)
+    nmu(:) = 0
+    do ib=1,nb
+      e1 = etv(ib)
+      do imu=1,mxmu
+        if (e1 <= mus(imu)) nmu(imu) = nmu(imu) + 1
+      enddo
+    enddo
+  end function n_of_mu
+
+end module iocc

--- a/PostHF/src/iocc.f90
+++ b/PostHF/src/iocc.f90
@@ -4,7 +4,7 @@ module iocc
   private
 
   public :: fill_bands, n_of_mu
-  public :: unique
+  public :: unique, quicksort
 
 contains
 

--- a/PostHF/src/iocc.f90
+++ b/PostHF/src/iocc.f90
@@ -1,10 +1,14 @@
 module iocc
   use kinds, only : dp
   implicit none
+  logical :: lsortocc = .false.
+  integer :: dnup = 0
+  integer :: dndn = 0
   private
 
   public :: fill_bands, n_of_mu
   public :: unique, quicksort
+  public :: lsortocc, dnup, dndn
 
 contains
 

--- a/PostHF/src/orbital_generators.f90
+++ b/PostHF/src/orbital_generators.f90
@@ -870,7 +870,6 @@ MODULE orbital_generators
     TYPE(h5file_type) :: h5id_wfn
     CHARACTER(len=10) :: ftype
     INTEGER :: i,j, ik, ispin, ikk, ia, n, mix_, err_,  nel, no
-    INTEGER :: mel ! maximum number of electrons per spin
     INTEGER :: non_coll, error, npw
     INTEGER :: maxl(2), Inel(2), maxnorb
     INTEGER, ALLOCATABLE :: nkocc(:,:)
@@ -901,27 +900,10 @@ MODULE orbital_generators
 
     allocate( nkocc(nksym,numspin) )
 
-    ! generate modified occupation tensor for calculation of trial wfn
-!    nelmax = 0
-!    do ispin=1,numspin
-!      do ik=1,nksym
-!        ikk = ik + nksym*(ispin-1)
-!        if(abs(wk(ikk))>1.d-10) then
-!            scl = 1.d0/wk(ikk)
-!        else 
-!            scl = 1.d0
-!        endif
-!        do ia=1,nbnd
-!          ! MAM: for high-T or for highly degenerate states this needs to be reduced
-!          ! maybe make it a parameter that defaults to 0.01
-!          if( abs(wg(ia,ikk)*scl) > 0.01d0 .and. ia > nelmax )  &
-!            nelmax = ia
-!        enddo
-!      enddo
-!    enddo
+    ! generate modified occupation tensor (wg_) for calculation of trial wfn
     neltot(:) = 0.d0
     if (lsortocc) then ! occupy according to sorted eigenvalues
-      ! step 1: determine maximum number of electrons per spin
+      ! step 1: count total number of electrons per spin
       neltot(1) = nksym*nelec
       if (nspin.eq.1) neltot(1) = neltot(1)/2
       neltot(1) = neltot(1) + dnup

--- a/PostHF/src/posthf.f90
+++ b/PostHF/src/posthf.f90
@@ -186,6 +186,9 @@ PROGRAM posthf
   CALL start_clock ( 'read_file' )
   CALL read_file
   CALL stop_clock ( 'read_file' )
+  ! check inputs
+  if (lsortocc.and.(dndn .ne. 0).and.(nspin.ne.2)) call errore('posthf', &
+   & 'number of down electrons is defined for nspin=2 only', 1)
 
   ! ntyp is initialized by read_file
   if (noncolin) then

--- a/PostHF/src/posthf.f90
+++ b/PostHF/src/posthf.f90
@@ -26,6 +26,7 @@ PROGRAM posthf
                     eha_    => eha,    &
                     vmoire_ => vmoire, &
                     pmoire_ => pmoire
+  USE iocc, ONLY : lsortocc, dnup, dndn
   USE input_parameters, ONLY : constrained_magnetization, starting_magnetization, &
     no_constrain_type, lambda, angle1, angle2
   USE noncollin_module, ONLY : noncolin, i_cons, mcons, lambda_ => lambda, npol, &
@@ -55,7 +56,7 @@ PROGRAM posthf
             regp,regkappa,read_from_h5,nextracut, update_qe_bands, run_type, diag_type, exxdiv_treatment, &
             lmoire, amoire_in_ang, vmoire_in_mev, pmoire_in_deg, mstar, epsmoire, &
             no_constrain_type, lambda, constrained_magnetization, starting_magnetization, &
-            angle1, angle2
+            angle1, angle2, lsortocc, dnup, dndn
 #ifdef __MPI
   CALL mp_startup ( )
 #endif
@@ -151,6 +152,9 @@ PROGRAM posthf
   CALL mp_bcast(starting_magnetization, ionode_id, world_comm)
   CALL mp_bcast(angle1, ionode_id, world_comm)
   CALL mp_bcast(angle2, ionode_id, world_comm)
+  CALL mp_bcast(lsortocc, ionode_id, world_comm)
+  CALL mp_bcast(dnup, ionode_id, world_comm)
+  CALL mp_bcast(dndn, ionode_id, world_comm)
   ! 
   ! ... transfer inputs to internal vairables
   ! 

--- a/PostHF/src/pp_utilities.f90
+++ b/PostHF/src/pp_utilities.f90
@@ -1037,14 +1037,14 @@ SUBROUTINE get_nelmax(nbnd,nk,ns,wk,n1,wg,nelmax)
   nelmax = 0
   if (lsortocc) then ! determine from input
     neltot(:) = 0
-    neltot(1) = nint(nelec) ! nspin 4
+    neltot(1) = nk*nint(nelec) ! nspin 4
     if (nspin.eq.1) neltot(1) = neltot(1)/2
     neltot(1) = neltot(1) + dnup
     if (nspin.eq.2) then
-      neltot(1) = nint(nelup) + dnup
-      neltot(2) = nint(neldw) + dndn
+      neltot(1) = nk*nint(nelup) + dnup
+      neltot(2) = nk*nint(neldw) + dndn
     endif
-    nelmax = max(neltot(1), neltot(2))
+    nelmax = ceiling(max(neltot(1), neltot(2))*1.d0/nk)
     if (nelmax>nbnd) call errore('get_nelmax', 'not enough orbitals', 1)
   else ! determine from fractional weights
   do ispin=1,ns

--- a/PostHF/src/pp_utilities.f90
+++ b/PostHF/src/pp_utilities.f90
@@ -1020,6 +1020,9 @@ END SUBROUTINE find_Q_symm
 SUBROUTINE get_nelmax(nbnd,nk,ns,wk,n1,wg,nelmax)
   !
   USE KINDS, ONLY : DP
+  USE lsda_mod, ONLY: nspin
+  USE klist, ONLY: nelec, nelup, neldw
+  use iocc, only : lsortocc, dnup, dndn
   !
   IMPLICIT NONE
   !
@@ -1029,8 +1032,21 @@ SUBROUTINE get_nelmax(nbnd,nk,ns,wk,n1,wg,nelmax)
   !
   INTEGER :: ispin,ik,ikk,ia
   REAL(DP) :: scl  
+  integer :: neltot(2)
   !  
   nelmax = 0
+  if (lsortocc) then ! determine from input
+    neltot(:) = 0
+    neltot(1) = nint(nelec) ! nspin 4
+    if (nspin.eq.1) neltot(1) = neltot(1)/2
+    neltot(1) = neltot(1) + dnup
+    if (nspin.eq.2) then
+      neltot(1) = nint(nelup) + dnup
+      neltot(2) = nint(neldw) + dndn
+    endif
+    nelmax = max(neltot(1), neltot(2))
+    if (nelmax>nbnd) call errore('get_nelmax', 'not enough orbitals', 1)
+  else ! determine from fractional weights
   do ispin=1,ns
     do ik=1,nk
       ikk = ik + nk*(ispin-1)
@@ -1046,6 +1062,7 @@ SUBROUTINE get_nelmax(nbnd,nk,ns,wk,n1,wg,nelmax)
       enddo
     enddo
   enddo
+  endif ! lsortocc
 END SUBROUTINE get_nelmax
 !-----------------------------------------------------------------------
 


### PR DESCRIPTION
`lsortocc = .true.` circumvents the fractional occupation problem.
This option sets occupation weights `wg_` by filling an integer number of orbitals from lowest to highest eigenvalue.
In the case of degenerate eigenvalues, a random subset is chosen to reach desired number of electrons.
Given the sorted eigenvalues, it should now be straightforward to make multideterminants.

This option also enables `dnup` and `dndn` inputs.
These allow one to add or remove electrons in each spin channel.
`dndn` is used for `nspin=2` only.